### PR TITLE
Fix no traces getting sent on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,24 @@ OTLP/gRPC.
 
 ## Setup
 
+### Installation
+
+To install nix-otel, it needs to be passed to Nix in the option `plugin-files`.
+[Currently](https://github.com/lf-/nix-otel/issues/3) nix-otel can only run on
+the Nix client, so my recommendation is to just use the flake from this
+repository and `--option plugin-files`, for now. In the future, it will be able
+to run on the daemon so it will be easier to install system wide.
+
+#### Important note
+
+You need to *ensure* that the version of Nix that `nix-otel` is loaded in is
+exactly the same as the one it's built against. We [found a strange macOS-only
+bug](https://github.com/lf-/nix-otel/pull/12) where `nix-otel` built against a
+different copy of Nix 2.11.0 than it was run against would not get any data.
+
+In practice, this means running with the `nix` binary provided by the `nix
+develop` shell from this project rather than the system Nix.
+
 ### Honeycomb
 
 Set env vars like so in `.envrc.local`:

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,7 @@
               # any dev tools you use in excess of the rust ones
               nativeBuildInputs = old.nativeBuildInputs ++ (
                 with pkgs; [
+                  nix
                   bear
                   rust-analyzer
                   rust-cbindgen


### PR DESCRIPTION
Yes, this change is absolutely baffling why it fixes the bug, but it does. I think that what happened is that even though both
/run/current-system/sw/bin/nix and the nix used by the flake are 2.11, we are still doing some kind of ABI crimes.

It seems that some kind of macOS shenanigans means that our copy of the nix::logger symbol is different than the one that Nix is using because of this, so the logger never gets overridden and we get no data.

The solution here is to *ensure* that the nix you call the plugin with is the same nix as it was built with, which we probably should have been doing in the first place anyway!