### PR TITLE
Dep bump

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1665259268,
-        "narHash": "sha256-ONFhHBLv5nZKhwV/F2GOH16197PbvpyWhoO0AOyktkU=",
+        "lastModified": 1691186842,
+        "narHash": "sha256-wxBVCvZUwq+XS4N4t9NqsHV4E64cPVqQ2fdDISpjcw0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c5924154f000e6306030300592f4282949b2db6c",
+        "rev": "18036c0be90f4e308ae3ebcab0e14aae0336fe42",
         "type": "github"
       },
       "original": {

--- a/plugin/build.rs
+++ b/plugin/build.rs
@@ -60,7 +60,7 @@ fn main() {
         .cpp(true)
         .opt_level(2)
         .shared_flag(true)
-        .flag("-std=c++17")
+        .flag("-std=c++20")
         .add_pkg_config(nix_expr)
         .add_pkg_config(nix_store)
         .add_pkg_config(nix_main)

--- a/plugin/build.rs
+++ b/plugin/build.rs
@@ -55,12 +55,23 @@ fn main() {
 
     let nix_ver = nix_expr.version.clone();
 
+    let mut parts = nix_ver.split('.').map(str::parse);
+    let major: u32 = parts.next().unwrap().unwrap();
+    let minor = parts.next().unwrap().unwrap();
+
+    let mut cpp_version = "20";
+
+    if (major, minor) <= (2, 11) {
+        cpp_version = "17";
+    }
+
+
     let mut build = cc::Build::new();
     build
         .cpp(true)
         .opt_level(2)
         .shared_flag(true)
-        .flag("-std=c++20")
+        .flag(&format!("-std=c++{}", cpp_version))
         .add_pkg_config(nix_expr)
         .add_pkg_config(nix_store)
         .add_pkg_config(nix_main)
@@ -72,10 +83,6 @@ fn main() {
     if cfg!(target_os = "macos") {
         println!("cargo:rustc-link-lib=c++");
     }
-
-    let mut parts = nix_ver.split('.').map(str::parse);
-    let major: u32 = parts.next().unwrap().unwrap();
-    let minor = parts.next().unwrap().unwrap();
 
     // Indicate that we need to patch around an API change with macros
     if (major, minor) >= (2, 4) {


### PR DESCRIPTION
This PR bumps nixpkgs. The most recent nix release is 2.17.1. In order to build with this (or even the most recent nixpkgs nix, 2.15), one has to change c++17 to c++20. The errors are pretty confusing, so I'm making this PR mostly for awareness.